### PR TITLE
Added removeAll method, which currently just drops the root node

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -242,6 +242,12 @@ export class Tree {
         return this
     }
 
+    removeAll() {
+        this.root = null
+
+        return this
+    }
+
     countParams(path) {
         let matches = path.match(/:|\*/g)
 

--- a/test/tree.js
+++ b/test/tree.js
@@ -326,4 +326,18 @@ describe('Tree', function() {
         expect(instance.find('/api/users')).to.be.ok
         expect(instance.find('/api/addresses')).to.be.ok
     })
+
+    it('clearing the tree should drop all nodes/paths', function () {
+        let instance = new Tree()
+
+        instance.add('/api/users')
+        instance.add('/api/users/new')
+        instance.add('/api/users/delete')
+
+        instance.removeAll()
+
+        expect(instance.find('/api/users')).to.not.be.ok
+        expect(instance.find('/api/users/new')).to.not.be.ok
+        expect(instance.find('/api/users/delete')).to.not.be.ok
+    })
 })


### PR DESCRIPTION
Closes #7 

Dropping the root node should be enough for the garbage collection to drop level by level, cause the remaining childs have no references anymore.
