### PR TITLE
Fixed an issue with exact match and similar paths in find and remove

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radix-tree",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Node.js version of a radix tree usable for routers or url path based storage.",
   "main": "index.js",
   "engines": {

--- a/src/tree.js
+++ b/src/tree.js
@@ -173,7 +173,7 @@ export class Tree {
                 let child = node.children[index]
 
                 if (child.type === Node.DEFAULT) {
-                    if ( path[offset] === child.path[0] ) {
+                    if ( path[offset] === child.path[0] && path.indexOf(child.path, offset) === offset ) {
                         node = child
                         offset += node.path.length
 
@@ -291,7 +291,7 @@ export class Tree {
                 let child = node.children[index]
 
                 if (child.type === Node.DEFAULT) {
-                    if ( path[offset] === child.path[0] ) {
+                    if ( path[offset] === child.path[0] && path.indexOf(child.path, offset) === offset ) {
                         node = child
                         offset += node.path.length
 

--- a/test/tree.js
+++ b/test/tree.js
@@ -89,6 +89,15 @@ describe('Tree', function() {
     })
 
 
+    it('should also work with very similar paths', function () {
+        let instance = new Tree()
+
+        instance.add('/test1')
+
+        expect(instance.find('/test1')).to.be.ok
+        expect(instance.find('/test2')).to.be.not.ok
+    })
+
     it('should return the node on exact match of the path', function () {
         let instance = new Tree()
 


### PR DESCRIPTION
This bug only occured when the tree was almost empty and we hit similar paths like an added path `/test1` and searching for `/test2` would return the `/test1` instead of `undefined`. Same for `remove()`.
