### PR TITLE
FIxed a bug with / and /: or /* generating an empty node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radix-tree",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Node.js version of a radix tree usable for routers or url path based storage.",
   "main": "index.js",
   "engines": {

--- a/src/tree.js
+++ b/src/tree.js
@@ -112,11 +112,13 @@ export class Tree {
                     throw new Error('Param node can not be appended to an already existing path')
                 }
 
-                child.path = path.substr(offset, index - offset)
+                if (offset < index - offset) {
+                    child.path = path.substr(offset, index - offset)
 
-                offset = index
-                node.append(child)
-                node = child
+                    offset = index
+                    node.append(child)
+                    node = child
+                }
 
                 child = new Node()
                 child.type = Node.PARAM
@@ -125,11 +127,13 @@ export class Tree {
                     throw new Error('Param node can not be appended to an already existing path')
                 }
 
-                child.path = path.substr(offset, index - offset)
+                if (offset < index - offset) {
+                    child.path = path.substr(offset, index - offset)
 
-                offset = index
-                node.append(child)
-                node = child
+                    offset = index
+                    node.append(child)
+                    node = child
+                }
 
                 child = new Node()
                 child.type = Node.CATCHALL

--- a/test/tree.js
+++ b/test/tree.js
@@ -139,11 +139,32 @@ describe('Tree', function() {
     it('should return the catchall param', function () {
         let instance = new Tree()
 
+        instance.add('/')
+        instance.add('/:id')
+
+        expect(instance.find('/')).to.deep.equal({path: '/'})
+        expect(instance.find('/some')).to.deep.equal({path: '/:id', params: {id: 'some'}})
+    })
+
+
+    it('should return the catchall param', function () {
+        let instance = new Tree()
+
         instance.add('/users')
         instance.add('/users/*api')
 
         expect(instance.find('/users')).to.deep.equal({path: '/users'})
         expect(instance.find('/users/some/path')).to.deep.equal({path: '/users/*api', params: {api: 'some/path'}})
+    })
+
+    it('should return the catchall param', function () {
+        let instance = new Tree()
+
+        instance.add('/')
+        instance.add('/*api')
+
+        expect(instance.find('/')).to.deep.equal({path: '/'})
+        expect(instance.find('/some/path')).to.deep.equal({path: '/*api', params: {api: 'some/path'}})
     })
 
     it('should be possible to mix both types', function () {


### PR DESCRIPTION
There is currently a bug that when adding the routes
- `/`
- `/*api`

and resolving `/test` will return `undefined` cause of an empty generated node.
